### PR TITLE
fix: sort directive keys alphabetically to comply with the directives_ordering linter rule

### DIFF
--- a/lib/src/directives_sorter.dart
+++ b/lib/src/directives_sorter.dart
@@ -249,7 +249,8 @@ void _add(
         buffer.writeln(directiveTypeComment);
       }
 
-      for (var directive in directives.keys) {
+      var keys = directives.keys.toList()..sort();
+      for (var directive in keys) {
         var comments = directives[directive]!;
         if (comments.isNotEmpty) {
           buffer.writeln(comments.join("\n"));

--- a/res/sorter_fixtures.dart
+++ b/res/sorter_fixtures.dart
@@ -50,8 +50,8 @@ import 'package:test/test.dart';
 import 'package:better_imports/lib.dart';
 
 // Relative Project Imports
-import 'cfg_test.dart';
 import '../res/sorter_fixtures.dart';
+import 'cfg_test.dart';
 
 part 'test.freezed.dart';
 part 'test.g.dart';
@@ -86,8 +86,8 @@ import 'package:test/test.dart';
 import '../lib/lib.dart';
 
 // Relative Project Imports
-import 'cfg_test.dart';
 import '../res/sorter_fixtures.dart';
+import 'cfg_test.dart';
 
 part 'test.freezed.dart';
 part 'test.g.dart';
@@ -118,8 +118,8 @@ import 'package:test/test.dart';
  */
 import 'package:better_imports/lib.dart';
 
-import 'cfg_test.dart';
 import '../res/sorter_fixtures.dart';
+import 'cfg_test.dart';
 
 part 'test.freezed.dart';
 part 'test.g.dart';
@@ -263,8 +263,8 @@ import 'package:test/test.dart';
 import 'package:better_imports/lib.dart';
 
 // Relative Project Imports
-import 'cfg_test.dart';
 import '../res/dart/dart/dart/dart/dart/dart/dart/dart/dart/dart/dart/dart/sorter_fixtures.dart';
+import 'cfg_test.dart';
 
 // Test Comment after imports
 void main() {

--- a/test/sorter_test.dart
+++ b/test/sorter_test.dart
@@ -90,6 +90,52 @@ void main() {
 
       expect(sorted.first.sorted, sortedFileWithCommentsRelative);
     });
+
+    test("Sorting file. Complies with directives_ordering linter rule.", () {
+      final unsorted = """
+import 'package:test/test.dart';
+import 'dart:io';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'dart:async';
+
+void main() {}
+""";
+      final file = File("res/unsorted_directives.dart");
+      file.writeAsStringSync(unsorted);
+
+      var argResult = argParser.parse([]);
+      var cfg = Cfg(argResult);
+      cfg.folders = ["res"];
+      cfg.files = ["unsorted_directives.dart"];
+      cfg.comments = false;
+
+      var collector = FilePathsCollector(cfg: cfg);
+      var collected = collector.collect();
+
+      var sorted = sort(collected, cfg);
+
+      expect(sorted.length, 1);
+      final sortedContent = sorted.first.sorted;
+      file.writeAsStringSync(sortedContent);
+
+      final analysisOptions = File("res/analysis_options.yaml");
+      analysisOptions.writeAsStringSync("""
+linter:
+  rules:
+    - directives_ordering
+""");
+
+      final result = Process.runSync('dart', ['analyze', file.path]);
+      
+      expect(
+        result.stdout.toString().contains('directives_ordering'),
+        isFalse,
+        reason: 'The sorted file should not violate directives_ordering.\nAnalyzer output: ${result.stdout}',
+      );
+
+      file.deleteSync();
+      analysisOptions.deleteSync();
+    });
   });
 
   group("Sorter Tests. Multiline with show. Issue #4", () {


### PR DESCRIPTION
This PR ensures that sorted imports comply with Dart's `directives_ordering` linter rule by enforcing strict alphabetical sorting within each import category block.
### Changes
- **Fixed:** Added `.sort()` to directive keys in `directives_sorter.dart` so imports within the same block (e.g., package, relative) are always sorted alphabetically.
- **Added:** A new test in `sorter_test.dart` that runs `dart analyze` to strictly verify the `directives_ordering` rule on the sorted output.
- **Updated:** Adjusted test fixtures in `sorter_fixtures.dart` to match the newly enforced alphabetical sorting logic.